### PR TITLE
Fix UI layout issues - mostly content clipping under header component

### DIFF
--- a/astro-app/src/pages/about.astro
+++ b/astro-app/src/pages/about.astro
@@ -16,23 +16,23 @@ if (!about) {
 
 <Layout title={`${about.title}`}>
   <section class="about">
-    <div class="about__layout">
-      {
-        about.image ? (
-          <div class="about__image">
-            <img
-              src={urlFor(about.image as Image).url()}
-              alt={about.image.alt || "About image"}
-            />
-          </div>
-        ) : null
-      }
-      <div class="about__content">
-        <div class="about__text">
-          <PortableText value={about.body!} components={{ block: Block }} />
+    <!-- <div class="about__layout"> -->
+    {
+      about.image ? (
+        <div class="about__image">
+          <img
+            src={urlFor(about.image as Image).url()}
+            alt={about.image.alt || "About image"}
+          />
         </div>
+      ) : null
+    }
+    <div class="about__content">
+      <div class="about__text">
+        <PortableText value={about.body!} components={{ block: Block }} />
       </div>
     </div>
+    <!-- </div> -->
   </section>
 </Layout>
 
@@ -52,14 +52,16 @@ if (!about) {
 
   .about__image {
     flex: 1 0 300px;
-    margin: 0;
+    max-width: 45%;
+    margin: 0 0 0 2rem;
+    float: right;
   }
 
   .about__image img {
     max-width: 100%;
     height: auto;
     border-radius: 8px;
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--drop-shadow-sm);
   }
 
   .about__text {
@@ -142,6 +144,8 @@ if (!about) {
     .about__image {
       flex: none;
       text-align: center;
+      max-width: 100%;
+      margin: var(--space-3) 0;
     }
   }
 
@@ -162,6 +166,8 @@ if (!about) {
     .about__image {
       flex: none;
       text-align: center;
+      max-width: 100%;
+      margin: var(--space-3) 0;
     }
 
     .about__text p {

--- a/astro-app/src/pages/article/[slug].astro
+++ b/astro-app/src/pages/article/[slug].astro
@@ -69,8 +69,8 @@ if (!post) {
   <style>
     .post {
       width: 100%;
-      margin: var(--space-1) auto var(--space-4);
-      padding: 0 var(--space-3);
+      margin: var(--space-7) auto var(--space-4);
+      padding: var(--space-2) var(--space-3);
       max-width: 1600px;
       background-color: var(--article-background-color);
 
@@ -157,7 +157,7 @@ if (!post) {
 
     @media (min-width: 575px) {
       .post {
-        padding: 0 var(--space-6);
+        padding: var(--space-2) var(--space-6);
 
         & .post__cover,
         & .post__cover--none {

--- a/astro-app/src/pages/index.astro
+++ b/astro-app/src/pages/index.astro
@@ -9,6 +9,7 @@ const posts = await getPosts();
 <Layout title="Jacob Robin | Creative Writer">
   {
     posts.length > 0 && (
+      <section class="posts__header"/>
       <section class="posts">
         <div class="posts__grid">
           {posts.map((post) => (
@@ -46,7 +47,7 @@ const posts = await getPosts();
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: var(--space-5);
     max-width: 100%;
-    align-items: center;
+    align-items: start;
     justify-content: center;
   }
 
@@ -62,7 +63,7 @@ const posts = await getPosts();
     .posts__grid {
       grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
       gap: var(--space-4);
-      align-items: center;
+      align-items: start;
     }
   }
 
@@ -74,7 +75,7 @@ const posts = await getPosts();
     .posts__grid {
       grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
       gap: var(--space-4);
-      align-items: center;
+      align-items: start;
     }
   }
 
@@ -86,7 +87,7 @@ const posts = await getPosts();
     .posts__grid {
       grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
       gap: var(--space-4);
-      align-items: center;
+      align-items: stretch;
     }
   }
 
@@ -98,7 +99,7 @@ const posts = await getPosts();
     .posts__grid {
       grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
       gap: var(--space-5);
-      align-items: center;
+      align-items: start;
     }
   }
 </style>


### PR DESCRIPTION
This pull request makes several improvements to the layout and styling of the `about`, `article`, and `index` pages in the Astro app. The main focus is on refining the visual presentation and alignment of content, as well as optimizing the layout for different screen sizes.

**About page layout and styling:**

* Commented out the `.about__layout` wrapper in `about.astro` to simplify the HTML structure. [[1]](diffhunk://#diff-b757db5b199a011d9984bfb0b7431eb6b97f751b53f73144cc38883da529dfd9L19-R19) [[2]](diffhunk://#diff-b757db5b199a011d9984bfb0b7431eb6b97f751b53f73144cc38883da529dfd9L35-R35)
* Updated `.about__image` styles to float the image right, set a `max-width`, and adjust margins for better alignment and responsiveness. Also updated the image box-shadow to use a CSS variable.
* Improved responsive design for `.about__image` by setting `max-width: 100%` and adjusting margins on smaller screens. [[1]](diffhunk://#diff-b757db5b199a011d9984bfb0b7431eb6b97f751b53f73144cc38883da529dfd9R147-R148) [[2]](diffhunk://#diff-b757db5b199a011d9984bfb0b7431eb6b97f751b53f73144cc38883da529dfd9R169-R170)

**Article page spacing:**

* Increased the top margin and padding of the `.post` class to provide more space above articles, and adjusted responsive padding for better readability. ([astro-app/src/pages/article/[slug].astroL72-R73](diffhunk://#diff-b81d24864bab99c34ea24b897eab2d782c287cb5a5e93279ce38ff9fdac62dd8L72-R73), [astro-app/src/pages/article/[slug].astroL160-R160](diffhunk://#diff-b81d24864bab99c34ea24b897eab2d782c287cb5a5e93279ce38ff9fdac62dd8L160-R160))

**Index page grid alignment:**

* Changed the alignment of `.posts__grid` items from `center` to `start` or `stretch` across various breakpoints, ensuring post cards align consistently at the top or stretch to fill the grid row. [[1]](diffhunk://#diff-fbe2f458e3de85ced9a3afaa89fff9421a69fd651f01ac6109fa6e4ada7ade16L49-R50) [[2]](diffhunk://#diff-fbe2f458e3de85ced9a3afaa89fff9421a69fd651f01ac6109fa6e4ada7ade16L65-R66) [[3]](diffhunk://#diff-fbe2f458e3de85ced9a3afaa89fff9421a69fd651f01ac6109fa6e4ada7ade16L77-R78) [[4]](diffhunk://#diff-fbe2f458e3de85ced9a3afaa89fff9421a69fd651f01ac6109fa6e4ada7ade16L89-R90) [[5]](diffhunk://#diff-fbe2f458e3de85ced9a3afaa89fff9421a69fd651f01ac6109fa6e4ada7ade16L101-R102)
* Added an empty `<section class="posts__header"/>` before the posts grid, possibly as a placeholder for future content or styling.…round image

style(article): update margin and padding to prevent image clipping under header

style(index): refine grid alignment and add header section to prevent clipping under header