### PR TITLE
Feat/seo improvements

### DIFF
--- a/astro-app/src/components/HeadMeta.astro
+++ b/astro-app/src/components/HeadMeta.astro
@@ -1,11 +1,22 @@
 ---
+import type { Image } from "@sanity/types";
+
+interface Props {
+  type?: string | undefined;
+  title: string;
+  description: string;
+  pubDate?: string | undefined;
+  updatedDate?: string | undefined;
+  image?: Image | undefined;
+}
+const { type, title, description, pubDate, updatedDate, image } = Astro.props;
+
 const canonicalURL = new URL(Astro.url.pathname, Astro.url);
 const siteURL = new URL("/", Astro.url);
 const webSiteSchema = new URL("/#/schema/WebSite", Astro.url);
 const jacobSchema = new URL("/#/schema/Person/jacobrobin", Astro.url);
 const josephSchema = new URL("/#/schema/Person/josephrissman", Astro.url);
-
-const { type, title, description, pubDate, updatedDate } = Astro.props;
+const imageSchema = new URL("/#/schema/Image/" + image?.asset?._ref, Astro.url);
 
 const structuredData = {
   "@context": "https://schema.org",
@@ -39,11 +50,17 @@ const structuredData = {
             isPartOf: {
               "@id": webSiteSchema,
             },
+            image: {
+              "@id": imageSchema,
+              caption: image?.alt,
+            },
             datePublished: pubDate,
             dateModified: updatedDate,
             author: {
               "@type": "Person",
               "@id": jacobSchema,
+              name: "Jacob Robin",
+              url: siteURL,
             },
           },
         ]

--- a/astro-app/src/components/HeadMeta.astro
+++ b/astro-app/src/components/HeadMeta.astro
@@ -50,9 +50,6 @@ const structuredData = {
             isPartOf: {
               "@id": webSiteSchema,
             },
-            image: {
-              "@id": imageSchema,
-              caption: image?.alt,
             ...(image
               ? {
                   image: {
@@ -76,4 +73,8 @@ const structuredData = {
 };
 ---
 
+<meta charset="UTF-8" />
 <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+<meta name="description" content={description} />
+<meta name="viewport" content="width=device-width" />
+<meta name="generator" content={Astro.generator} />

--- a/astro-app/src/components/HeadMeta.astro
+++ b/astro-app/src/components/HeadMeta.astro
@@ -53,7 +53,14 @@ const structuredData = {
             image: {
               "@id": imageSchema,
               caption: image?.alt,
-            },
+            ...(image
+              ? {
+                  image: {
+                    "@id": imageSchema,
+                    caption: image?.alt,
+                  },
+                }
+              : {}),
             datePublished: pubDate,
             dateModified: updatedDate,
             author: {

--- a/astro-app/src/components/HeadMeta.astro
+++ b/astro-app/src/components/HeadMeta.astro
@@ -1,0 +1,55 @@
+---
+const canonicalURL = new URL(Astro.url.pathname, Astro.url);
+const siteURL = new URL("/", Astro.url);
+const webSiteSchema = new URL("/#/schema/WebSite", Astro.url);
+const jacobSchema = new URL("/#/schema/Person/jacobrobin", Astro.url);
+const josephSchema = new URL("/#/schema/Person/josephrissman", Astro.url);
+
+const { type, title, description, pubDate, updatedDate } = Astro.props;
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": webSiteSchema,
+      name: title,
+      description: description,
+      url: siteURL,
+      publisher: {
+        "@type": "Person",
+        "@id": josephSchema,
+        name: "Joseph Rissman",
+        url: "https://www.josephrissman.com",
+        sameAs: [
+          "https://www.linkedin.com/in/joseph-rissman/",
+          "https://github.com/jirissman",
+        ],
+      },
+    },
+    ...(type
+      ? [
+          {
+            "@type": type,
+            "@id": canonicalURL,
+            url: canonicalURL,
+            name: title,
+            headline: title,
+            description: description,
+            isPartOf: {
+              "@id": webSiteSchema,
+            },
+            datePublished: pubDate,
+            dateModified: updatedDate,
+            author: {
+              "@type": "Person",
+              "@id": jacobSchema,
+            },
+          },
+        ]
+      : []),
+  ],
+};
+---
+
+<script type="application/ld+json" set:html={JSON.stringify(structuredData)} />

--- a/astro-app/src/components/index.ts
+++ b/astro-app/src/components/index.ts
@@ -3,3 +3,4 @@ export { default as Footer } from "./Footer.astro";
 export { default as Card } from "./Card.astro";
 export { default as ThemeManager } from "./ThemeManager.astro";
 export { default as ThemeToggleButton } from "./ThemeToggleButton.astro";
+export { default as HeadMeta } from "./HeadMeta.astro";

--- a/astro-app/src/layouts/Layout.astro
+++ b/astro-app/src/layouts/Layout.astro
@@ -14,6 +14,7 @@ import {
   DEFAULT_TYPOGRAPHY,
   DEFAULT_LAYOUT,
 } from "../../../shared/defaults";
+import type { Image } from "@sanity/types";
 
 interface Props {
   type?: string | undefined;
@@ -21,6 +22,7 @@ interface Props {
   description?: string | undefined;
   pubDate?: string | undefined;
   updatedDate?: string | undefined;
+  image?: Image | undefined;
 }
 
 const {
@@ -29,6 +31,7 @@ const {
   description = "Jacob Robin is a creative writer specializing in immersive storytelling and engaging content.",
   pubDate,
   updatedDate,
+  image,
 } = Astro.props;
 const darkTheme = await getDarkTheme();
 const lightTheme = await getLightTheme();
@@ -46,6 +49,7 @@ const layout = await getLayoutSettings();
       description={description}
       pubDate={pubDate}
       updatedDate={updatedDate}
+      image={image}
     />
     <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width" />

--- a/astro-app/src/layouts/Layout.astro
+++ b/astro-app/src/layouts/Layout.astro
@@ -42,7 +42,6 @@ const layout = await getLayoutSettings();
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
     <HeadMeta
       type={type}
       title={title}
@@ -51,10 +50,7 @@ const layout = await getLayoutSettings();
       updatedDate={updatedDate}
       image={image}
     />
-    <meta name="description" content={description} />
-    <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="generator" content={Astro.generator} />
 
     <!-- Google fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/astro-app/src/layouts/Layout.astro
+++ b/astro-app/src/layouts/Layout.astro
@@ -1,7 +1,7 @@
 ---
 // https://docs.astro.build/en/guides/view-transitions/
 import { ClientRouter } from "astro:transitions";
-import { Header, Footer, ThemeManager } from "../components";
+import { Header, Footer, ThemeManager, HeadMeta } from "../components";
 import "../styles/global.css";
 import {
   getDarkTheme,
@@ -16,13 +16,19 @@ import {
 } from "../../../shared/defaults";
 
 interface Props {
+  type?: string | undefined;
   title?: string | undefined;
   description?: string | undefined;
+  pubDate?: string | undefined;
+  updatedDate?: string | undefined;
 }
 
 const {
+  type,
   title = "Jacob Robin | Creative Writer",
   description = "Jacob Robin is a creative writer specializing in immersive storytelling and engaging content.",
+  pubDate,
+  updatedDate,
 } = Astro.props;
 const darkTheme = await getDarkTheme();
 const lightTheme = await getLightTheme();
@@ -34,20 +40,13 @@ const layout = await getLayoutSettings();
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <!-- Google Tag Manager -->
-    <script is:inline>
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != "dataLayer" ? "&l=" + l : "";
-        j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-        f.parentNode.insertBefore(j, f);
-      })(window, document, "script", "dataLayer", "GTM-KPX99W9Q");
-    </script>
-    <!-- End Google Tag Manager -->
+    <HeadMeta
+      type={type}
+      title={title}
+      description={description}
+      pubDate={pubDate}
+      updatedDate={updatedDate}
+    />
     <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -66,15 +65,6 @@ const layout = await getLayoutSettings();
     <ThemeManager defaultTheme="auto" />
   </head>
   <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript
-      ><iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-KPX99W9Q"
-        height="0"
-        width="0"
-        style="display:none;visibility:hidden"></iframe></noscript
-    >
-    <!-- End Google Tag Manager (noscript) -->
     <div class="container">
       <Header />
       <main>

--- a/astro-app/src/layouts/Layout.astro
+++ b/astro-app/src/layouts/Layout.astro
@@ -16,10 +16,14 @@ import {
 } from "../../../shared/defaults";
 
 interface Props {
-  title: string;
+  title?: string | undefined;
+  description?: string | undefined;
 }
 
-const { title } = Astro.props;
+const {
+  title = "Jacob Robin | Creative Writer",
+  description = "Jacob Robin is a creative writer specializing in immersive storytelling and engaging content.",
+} = Astro.props;
 const darkTheme = await getDarkTheme();
 const lightTheme = await getLightTheme();
 const typography = await getTypography();
@@ -30,6 +34,21 @@ const layout = await getLayoutSettings();
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- Google Tag Manager -->
+    <script is:inline>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != "dataLayer" ? "&l=" + l : "";
+        j.async = true;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, "script", "dataLayer", "GTM-KPX99W9Q");
+    </script>
+    <!-- End Google Tag Manager -->
+    <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
@@ -47,6 +66,15 @@ const layout = await getLayoutSettings();
     <ThemeManager defaultTheme="auto" />
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript
+      ><iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-KPX99W9Q"
+        height="0"
+        width="0"
+        style="display:none;visibility:hidden"></iframe></noscript
+    >
+    <!-- End Google Tag Manager (noscript) -->
     <div class="container">
       <Header />
       <main>

--- a/astro-app/src/pages/404.astro
+++ b/astro-app/src/pages/404.astro
@@ -2,7 +2,7 @@
 import Layout from "../layouts/Layout.astro";
 ---
 
-<Layout title="404 - Page Not Found">
+<Layout>
   <section class="error-page">
     <div class="error-page__container">
       <div class="error-page__content">

--- a/astro-app/src/pages/article/[slug].astro
+++ b/astro-app/src/pages/article/[slug].astro
@@ -17,6 +17,7 @@ if (!post) {
   return Astro.redirect("/404");
 }
 
+const pubDate = dayjs(post.publishedAt).format();
 // TODO: Open Graph tags, and Schema.org structured data for SEO
 // TODO: Consider extracting repeated magic numbers (750, 380, 200) to CSS custom properties
 ---
@@ -24,8 +25,9 @@ if (!post) {
 <Layout
   type="Article"
   title={post.title!}
-  pubDate={post.publishedAt}
+  pubDate={pubDate}
   updatedDate={post._updatedAt}
+  image={post.mainImage as Image}
 >
   <section class="post">
     {

--- a/astro-app/src/pages/article/[slug].astro
+++ b/astro-app/src/pages/article/[slug].astro
@@ -21,7 +21,12 @@ if (!post) {
 // TODO: Consider extracting repeated magic numbers (750, 380, 200) to CSS custom properties
 ---
 
-<Layout title={post.title!}>
+<Layout
+  type="Article"
+  title={post.title!}
+  pubDate={post.publishedAt}
+  updatedDate={post._updatedAt}
+>
   <section class="post">
     {
       post.mainImage ? (

--- a/astro-app/src/pages/article/[slug].astro
+++ b/astro-app/src/pages/article/[slug].astro
@@ -17,7 +17,7 @@ if (!post) {
   return Astro.redirect("/404");
 }
 
-// TODO: Add meta description, Open Graph tags, and Schema.org structured data for SEO
+// TODO: Open Graph tags, and Schema.org structured data for SEO
 // TODO: Consider extracting repeated magic numbers (750, 380, 200) to CSS custom properties
 ---
 

--- a/astro-app/src/pages/index.astro
+++ b/astro-app/src/pages/index.astro
@@ -6,7 +6,10 @@ import { getPosts } from "../utils/sanity";
 const posts = await getPosts();
 ---
 
-<Layout title="Jacob Robin | Creative Writer">
+<Layout
+  title="Jacob Robin | Creative Writer"
+  description="Personal website for Jacob Robin, a creative writer and storyteller."
+>
   {
     posts.length > 0 && (
       <section class="posts__header"/>


### PR DESCRIPTION
This pull request introduces a reusable `HeadMeta` component to manage SEO metadata and structured data across the Astro app. The `Layout` component and relevant pages are updated to use this new component, ensuring consistent and enhanced SEO support (including Schema.org structured data) for all pages. Additionally, the props for `Layout` are expanded to allow flexible metadata configuration.

**SEO and Metadata Improvements:**

* Added a new `HeadMeta.astro` component that generates structured data (Schema.org) and injects SEO-relevant metadata into the page head. This includes support for article and website schemas and dynamic publisher/author info.
* Updated `Layout.astro` to accept new metadata props (`type`, `description`, `pubDate`, `updatedDate`, `image`) and use the `HeadMeta` component for consistent metadata injection across all pages. Default values are provided for missing props. [[1]](diffhunk://#diff-cfd267043ab6384b291c9a0c41e26c3b7ae02b9d3e672e434e3a24651a159fa8R17-R35) [[2]](diffhunk://#diff-cfd267043ab6384b291c9a0c41e26c3b7ae02b9d3e672e434e3a24651a159fa8R46-R54)

**Component and Import Refactoring:**

* Exported the new `HeadMeta` component from the components index for easy import elsewhere in the app.

**Page Integration Updates:**

* Updated the homepage (`index.astro`) and article page (`[slug].astro`) to pass appropriate metadata props to `Layout`, enabling rich metadata and structured data for these pages. ([astro-app/src/pages/index.astroL9-R12](diffhunk://#diff-fbe2f458e3de85ced9a3afaa89fff9421a69fd651f01ac6109fa6e4ada7ade16L9-R12), [astro-app/src/pages/article/[slug].astroL20-R31](diffhunk://#diff-b81d24864bab99c34ea24b897eab2d782c287cb5a5e93279ce38ff9fdac62dd8L20-R31))
* Removed the hardcoded title from the 404 page, allowing `Layout` to handle defaults and metadata.